### PR TITLE
chore: restrict Vercel builds to prod branch only

### DIFF
--- a/backoffice/vercel.json
+++ b/backoffice/vercel.json
@@ -5,12 +5,13 @@
       "prod": true,
       "develop": false,
       "staging": false,
-      "preview": false
+      "preview": false,
+      "*": false
     }
   },
-  "buildCommand": "pnpm install && pnpm build",
+  "buildCommand": "if [ \"$VERCEL_GIT_COMMIT_REF\" = \"prod\" ]; then pnpm install && pnpm build; else echo '🚫 Builds only allowed on prod branch' && exit 1; fi",
   "outputDirectory": ".next",
-  "ignoreCommand": "if [ \"$VERCEL_GIT_COMMIT_REF\" != \"prod\" ]; then echo '🚫 Skipping deployment for non-production branch: $VERCEL_GIT_COMMIT_REF'; exit 1; fi",
+  "ignoreCommand": "if [ \"$VERCEL_GIT_COMMIT_REF\" != \"prod\" ]; then echo '🚫 Deployment skipped: $VERCEL_GIT_COMMIT_REF is not prod branch' && exit 1; fi",
   "functions": {
     "app/api/**/*.ts": {
       "maxDuration": 30

--- a/frontend/vercel.json
+++ b/frontend/vercel.json
@@ -5,12 +5,13 @@
       "prod": true,
       "develop": false,
       "staging": false,
-      "preview": false
+      "preview": false,
+      "*": false
     }
   },
-  "buildCommand": "pnpm install && pnpm build",
+  "buildCommand": "if [ \"$VERCEL_GIT_COMMIT_REF\" = \"prod\" ]; then pnpm install && pnpm build; else echo '🚫 Builds only allowed on prod branch' && exit 1; fi",
   "outputDirectory": ".next",
-  "ignoreCommand": "if [ \"$VERCEL_GIT_COMMIT_REF\" != \"prod\" ]; then echo '🚫 Skipping deployment for non-production branch: $VERCEL_GIT_COMMIT_REF'; exit 1; fi",
+  "ignoreCommand": "if [ \"$VERCEL_GIT_COMMIT_REF\" != \"prod\" ]; then echo '🚫 Deployment skipped: $VERCEL_GIT_COMMIT_REF is not prod branch' && exit 1; fi",
   "functions": {
     "app/api/**/*.ts": {
       "maxDuration": 30


### PR DESCRIPTION
This PR updates Vercel configuration to ensure builds only happen on the prod branch.

Changes made to both frontend and backoffice vercel.json:

1. Added "*": false to deploymentEnabled to block all unspecified branches
2. Modified buildCommand to explicitly check for "prod" branch
3. Updated ignoreCommand with clearer messages
4. Kept configuration consistent across both projects

This ensures:
- Only prod branch can trigger builds and deployments
- All other branches (including main) will skip builds
- Clear error messages when builds are skipped

Testing:
- Pushing to prod branch should trigger builds
- Pushing to main or any other branch should skip builds with clear message