### PR TITLE
chore: update TypeScript and ESLint tools

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -55,7 +55,7 @@
     "@types/multer": "^2.0.0",
     "@types/node": "^22.15.30",
     "@typescript-eslint/eslint-plugin": "^8.43.0",
-    "@typescript-eslint/parser": "^7.0.0",
+    "@typescript-eslint/parser": "^8.43.0",
     "eslint": "^8.56.0",
     "prisma": "^6.10.1",
     "ts-node": "^10.9.2",

--- a/backend/package.json
+++ b/backend/package.json
@@ -53,7 +53,7 @@
     "@types/express-rate-limit": "^6.0.2",
     "@types/jsonwebtoken": "^9.0.5",
     "@types/multer": "^2.0.0",
-    "@types/node": "^22.15.30",
+    "@types/node": "^24.3.1",
     "@typescript-eslint/eslint-plugin": "^8.43.0",
     "@typescript-eslint/parser": "^8.43.0",
     "eslint": "^8.56.0",

--- a/backend/package.json
+++ b/backend/package.json
@@ -54,7 +54,7 @@
     "@types/jsonwebtoken": "^9.0.5",
     "@types/multer": "^2.0.0",
     "@types/node": "^22.15.30",
-    "@typescript-eslint/eslint-plugin": "^7.0.0",
+    "@typescript-eslint/eslint-plugin": "^8.43.0",
     "@typescript-eslint/parser": "^7.0.0",
     "eslint": "^8.56.0",
     "prisma": "^6.10.1",

--- a/shared/package.json
+++ b/shared/package.json
@@ -18,7 +18,7 @@
     "@types/node": "^22",
     "@typescript-eslint/eslint-plugin": "^7.0.0",
     "@typescript-eslint/parser": "^7.0.0",
-    "eslint": "^8.56.0",
+    "eslint": "^9.35.0",
     "tsup": "^8.0.2",
     "typescript": "^5"
   }

--- a/shared/package.json
+++ b/shared/package.json
@@ -16,10 +16,10 @@
   },
   "devDependencies": {
     "@types/node": "^22",
-    "@typescript-eslint/eslint-plugin": "^7.0.0",
-    "@typescript-eslint/parser": "^7.0.0",
+    "@typescript-eslint/eslint-plugin": "^8.43.0",
+    "@typescript-eslint/parser": "^8.43.0",
     "eslint": "^9.35.0",
     "tsup": "^8.0.2",
     "typescript": "^5"
   }
-} 
+}

--- a/shared/package.json
+++ b/shared/package.json
@@ -15,7 +15,7 @@
     "zod": "^4.1.5"
   },
   "devDependencies": {
-    "@types/node": "^22",
+    "@types/node": "^24.3.1",
     "@typescript-eslint/eslint-plugin": "^8.43.0",
     "@typescript-eslint/parser": "^8.43.0",
     "eslint": "^9.35.0",


### PR DESCRIPTION
This PR updates TypeScript and ESLint related dependencies:

Backend:
- @typescript-eslint/eslint-plugin: ^8.43.0
- @typescript-eslint/parser: ^8.43.0
- @types/node: ^24.3.1

Shared:
- @typescript-eslint/eslint-plugin: ^8.43.0
- @typescript-eslint/parser: ^8.43.0
- eslint: ^9.35.0
- @types/node: ^24.3.1

All updates have been tested:
- ✅ Backend builds successfully
- ✅ Shared library builds successfully
- ✅ All projects build without TypeScript errors

This PR will supersede the following Dependabot PRs:
- #23 (typescript-eslint/eslint-plugin in backend)
- #19 (typescript-eslint/parser in backend)
- #18 (@types/node in backend)
- #16 (typescript-eslint/parser in shared)
- #12 (eslint in shared)
- #9 (@types/node in shared)
- #7 (typescript-eslint/eslint-plugin in shared)

All components have been tested and build successfully.