### PR TITLE
fix: allow Vercel builds on PRs but only deploy from prod

### DIFF
--- a/backoffice/vercel.json
+++ b/backoffice/vercel.json
@@ -9,9 +9,9 @@
       "*": false
     }
   },
-  "buildCommand": "if [ \"$VERCEL_GIT_COMMIT_REF\" = \"prod\" ]; then pnpm install && pnpm build; else echo '🚫 Builds only allowed on prod branch' && exit 1; fi",
+  "buildCommand": "pnpm install && pnpm build",
   "outputDirectory": ".next",
-  "ignoreCommand": "if [ \"$VERCEL_GIT_COMMIT_REF\" != \"prod\" ]; then echo '🚫 Deployment skipped: $VERCEL_GIT_COMMIT_REF is not prod branch' && exit 1; fi",
+  "ignoreCommand": "if [ \"$VERCEL_GIT_COMMIT_REF\" != \"prod\" ]; then echo '🚫 Preview deployment skipped: $VERCEL_GIT_COMMIT_REF is not prod branch' && exit 0; fi",
   "functions": {
     "app/api/**/*.ts": {
       "maxDuration": 30

--- a/frontend/vercel.json
+++ b/frontend/vercel.json
@@ -9,9 +9,9 @@
       "*": false
     }
   },
-  "buildCommand": "if [ \"$VERCEL_GIT_COMMIT_REF\" = \"prod\" ]; then pnpm install && pnpm build; else echo '🚫 Builds only allowed on prod branch' && exit 1; fi",
+  "buildCommand": "pnpm install && pnpm build",
   "outputDirectory": ".next",
-  "ignoreCommand": "if [ \"$VERCEL_GIT_COMMIT_REF\" != \"prod\" ]; then echo '🚫 Deployment skipped: $VERCEL_GIT_COMMIT_REF is not prod branch' && exit 1; fi",
+  "ignoreCommand": "if [ \"$VERCEL_GIT_COMMIT_REF\" != \"prod\" ]; then echo '🚫 Preview deployment skipped: $VERCEL_GIT_COMMIT_REF is not prod branch' && exit 0; fi",
   "functions": {
     "app/api/**/*.ts": {
       "maxDuration": 30


### PR DESCRIPTION
This PR fixes our Vercel configuration to handle PR builds correctly:

Current issues:
- PR builds are failing because we're forcing exit code 1 on non-prod branches
- This causes PRs to fail checks even when the code is good
- We've had to bypass branch protection rules to merge PRs

Changes made:
1. Allow builds on all branches (to validate PRs)
2. Skip deployments (but don't fail) for non-prod branches
3. Keep deployment restrictions to only deploy from prod branch

This means:
- PRs will build to validate code ✅
- Only prod branch will deploy 🚀
- Branch protection rules can work properly 🔒

This will allow us to:
1. Merge PRs normally without bypassing rules
2. Still keep our deployment control (only from prod)
3. Have proper CI/CD validation on PRs